### PR TITLE
fix:修复判断角色是否被引用的错误

### DIFF
--- a/opsli-modulars/opsli-modulars-system/src/main/java/org/opsli/modulars/system/user/service/impl/UserRoleRefServiceImpl.java
+++ b/opsli-modulars/opsli-modulars-system/src/main/java/org/opsli/modulars/system/user/service/impl/UserRoleRefServiceImpl.java
@@ -338,7 +338,7 @@ public class UserRoleRefServiceImpl extends ServiceImpl<UserRoleRefMapper, SysUs
         QueryWrapper<SysUserRoleRef> queryWrapper = new QueryWrapper<>();
         queryWrapper.eq("role_id", roleId);
 
-        return this.count(queryWrapper) == 0;
+        return this.count(queryWrapper) > 0;
     }
 
     @Override
@@ -350,7 +350,7 @@ public class UserRoleRefServiceImpl extends ServiceImpl<UserRoleRefMapper, SysUs
         QueryWrapper<SysUserRoleRef> queryWrapper = new QueryWrapper<>();
         queryWrapper.in("role_id", Convert.toList(roleIds));
 
-        return this.count(queryWrapper) == 0;
+        return this.count(queryWrapper) > 0;
     }
 
 


### PR DESCRIPTION
- 现象：刚新建的角色无法删除
- 原因：判断角色是否被引用的逻辑错误
- 修改：数据库查出count>0时角色才是被引用