### PR TITLE
fix(sec): upgrade org.yaml:snakeyaml to 1.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <guava.version>30.0-android</guava.version>
         <commons.io.version>2.11.0</commons.io.version>
         <commons.lang3.version>3.11</commons.lang3.version>
-        <snakeyaml.version>1.27</snakeyaml.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
         <email.version>1.6.2</email.version>
         <logback.version>1.2.9</logback.version>
         <protobuf-java.version>3.18.2</protobuf-java.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.yaml:snakeyaml 1.27
- [CVE-2022-25857](https://www.oscs1024.com/hd/CVE-2022-25857)


### What did I do？
Upgrade org.yaml:snakeyaml from 1.27 to 1.32 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS